### PR TITLE
Reverting back to before the addition of Delivery Date column

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,27 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+
+trigger:
+- secrets-feature
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+- task: Docker@2
+  inputs:
+    containerRegistry: 'Docker Hub'
+    repository: 'mayaaiuga/flask-app-sercrets'
+    command: 'buildAndPush'
+    Dockerfile: '**/Dockerfile'
+    tags: 'latest'
+- task: KubernetesManifest@1
+  inputs:
+    action: 'deploy'
+    connectionType: 'azureResourceManager'
+    azureSubscriptionConnection: 'aks-service-connection'
+    azureResourceGroup: 'aks-rg'
+    kubernetesCluster: 'aks-demo'
+    manifests: 'deployment.yaml'


### PR DESCRIPTION
The revert-delivery-date branch reverts to the commit 899ac, from before the addition of the "Delivery Date" column, since this column addition is not needed.